### PR TITLE
Yarn command to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ File sizes displayed by this tool reflect size of transpiled minified bundled co
 npm install bundle-analyzer -g
 
 # Yarn
-yarn add bundle-analyzer --global
+yarn global add bundle-analyzer
 ```
 
 ---


### PR DESCRIPTION
According to the [Yarn documentation](https://yarnpkg.com/en/docs/cli/global), `global` must immediately follow `yarn`. So the command must be `yarn global add bundle-analyzer`.